### PR TITLE
Some small tweaks, new tests and docs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -18,6 +18,7 @@ APIs:
   * [Contents](repo/contents.md)
   * [Releases](repo/releases.md)
     * [Assets](repo/assets.md)
+  * [Deployments](repo/deployments.md)
 * [Users](users.md)
 * [Meta](meta.md)
 

--- a/doc/repo/deployments.md
+++ b/doc/repo/deployments.md
@@ -1,0 +1,40 @@
+## Repo / Deployments API
+[Back to the "Repos API"](../repos.md) | [Back to the navigation](../index.md)
+
+Provides information about deployments for a repository. Wraps [GitHub Deployments API](https://developer.github.com/v3/repos/deployments/).
+
+#### List all deployments.
+
+```php
+$deployments = $client->api('deployment')->all('KnpLabs', 'php-github-api');
+```
+
+You can also filter the returned results (see [the documentation](https://developer.github.com/v3/repos/deployments/#list-deployments) for more information):
+
+```php
+$deployments = $client->api('deployment')->all('KnpLabs', 'php-github-api', array('environment' => 'production'));
+```
+
+#### Create a new deployments.
+
+The `ref` parameter is required.
+
+```php
+$data = $client->api('deployment')->create('KnpLabs', 'php-github-api', array('ref' => 'fd6a5f9e5a430dddae8d6a8ea378f913d3a766f9'));
+```
+
+Please note that once a deployment is created it cannot be edited. Only status updates can be created.
+
+#### Create a new status update.
+
+The `state` parameter is required. At the time of writing, this must be pending, success, error, or failure.
+
+```php
+$data = $client->api('deployment')->updateStatus('KnpLabs', 'php-github-api', 1, array('state' => 'error', 'description' => 'syntax error'));
+```
+
+#### Get all status updates for a deployment.
+
+```php
+$statusUpdates = $client->api('deployment')->getStatuses('KnpLabs', 'php-github-api', 1);
+```

--- a/lib/Github/Api/Deployment.php
+++ b/lib/Github/Api/Deployment.php
@@ -4,20 +4,33 @@ namespace Github\Api;
 
 use Github\Exception\MissingArgumentException;
 
+/**
+ * Listing, creating and updating deployments.
+ *
+ * @link https://developer.github.com/v3/repos/deployments/
+ */
 class Deployment extends AbstractApi
 {
-
+    /**
+     * List deployments for a particular repository
+     * @link https://developer.github.com/v3/repos/deployments/#list-deployments
+     *
+     * @param  string $username   the username of the user who owns the repository
+     * @param  string $repository the name of the repository
+     * @param  array $params      query parameters to filter deployments by (see link)
+     * @return array              the deployments requested
+     */
     public function all($username, $repository, array $params = array())
     {   
-        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', array(),
-          array('Accept' => 'application/vnd.github.cannonball-preview+json')
-        );
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params);
     }
-
-
 
     /**
      * Create a new deployment for the given username and repo.
+     * @link https://developer.github.com/v3/repos/deployments/#create-a-deployment
+     *
+     * Important: Once a deployment is created, it cannot be updated. Changes are indicated by creating new statuses.
+     * @see updateStatus
      *
      * @param  string $username   the username
      * @param  string $repository the repository
@@ -32,22 +45,40 @@ class Deployment extends AbstractApi
              throw new MissingArgumentException(array('ref'));
          }
 
-         return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params, ['Accept' => 'application/vnd.github.cannonball-preview+json']);
+         return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments', $params);
     }
 
     /**
-     * Update deployment information's by username, repo and deployment number. Requires authentication.
+     * Updates a deployment by creating a new status update.
+     * @link https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
      *
-     * @param string $username   the username
+     * @param string $username the username
      * @param string $repository the repository
-     * @param string $id         the deployment number
+     * @param string $id the deployment number
+     * @param array $params The information about the deployment update.
+     *                       Must include a "state" field of pending, success, error, or failure.
+     *                       May also be given a target_url and description, ßee link for more details.
      * @return array information about the deployment
+     *
+     * @throws MissingArgumentException
      */
-    public function update($username, $repository, $id, array $params)
+    public function updateStatus($username, $repository, $id, array $params)
     {
          if (!isset($params['state'])) {
            throw new MissingArgumentException(array('state'));
          }
-         return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses', $params, ['Accept' => 'application/vnd.github.cannonball-preview+json']);
+         return $this->post('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses', $params);
+    }
+
+    /**
+     * Gets all of the status updates tied to a given deployment.
+     *
+     * @param  string $username the username
+     * @param  string $repository the repository
+     * @param  int $id the deployment identifier
+     * @return array the deployment statuses
+     */
+    public function getStatuses($username, $repository, $id) {
+        return $this->get('repos/'.rawurlencode($username).'/'.rawurlencode($repository).'/deployments/'.rawurlencode($id).'/statuses');
     }
 }

--- a/test/Github/Tests/Api/DeploymentTest.php
+++ b/test/Github/Tests/Api/DeploymentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Github\Tests\Api;
+
+class DeploymentTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldCreateDeployment()
+    {
+        /** @var \Github\Api\Deployment $api */
+        $api = $this->getApiMock();
+        $deploymentData = array("ref" => "fd6a5f9e5a430dddae8d6a8ea378f913d3a766f9");
+        $api->expects($this->once())
+            ->method('post')
+            ->with('/repos/KnpLabs/php-github-api/deployments', $deploymentData);
+
+        $api->create("KnpLabs", "php-github-api", $deploymentData);
+    }
+
+    protected function getApiClass()
+    {
+        return 'Github\Api\Deployment';
+    }
+}

--- a/test/Github/Tests/Api/DeploymentTest.php
+++ b/test/Github/Tests/Api/DeploymentTest.php
@@ -9,14 +9,81 @@ class DeploymentTest extends TestCase
      */
     public function shouldCreateDeployment()
     {
-        /** @var \Github\Api\Deployment $api */
         $api = $this->getApiMock();
         $deploymentData = array("ref" => "fd6a5f9e5a430dddae8d6a8ea378f913d3a766f9");
         $api->expects($this->once())
             ->method('post')
-            ->with('/repos/KnpLabs/php-github-api/deployments', $deploymentData);
+            ->with('repos/KnpLabs/php-github-api/deployments', $deploymentData);
 
         $api->create("KnpLabs", "php-github-api", $deploymentData);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllDeployments()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/deployments');
+
+        $api->all("KnpLabs", "php-github-api");
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllDeploymentsWithFilterParameters()
+    {
+        $api = $this->getApiMock();
+        $filterData = ["foo" => "bar", "bar" => "foo"];
+
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/deployments', $filterData);
+
+        $api->all("KnpLabs", "php-github-api", $filterData);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateStatusUpdate()
+    {
+        $api = $this->getApiMock();
+        $statusData = ["state" => "pending", "description" => "waiting to start"];
+
+        $api->expects($this->once())
+            ->method('post')
+            ->with('repos/KnpLabs/php-github-api/deployments/1/statuses', $statusData);
+
+        $api->updateStatus("KnpLabs", "php-github-api", 1, $statusData);
+    }
+
+    /**
+     * @test
+     * @expectedException GitHub\Exception\MissingArgumentException
+     */
+    public function shouldRejectStatusUpdateWithoutStateField()
+    {
+        $api = $this->getApiMock();
+        $statusData = [ "description" => "waiting to start"];
+
+        $api->updateStatus("KnpLabs", "php-github-api", 1, $statusData);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGetAllStatuses()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with('repos/KnpLabs/php-github-api/deployments/1/statuses');
+
+        $api->getStatuses("KnpLabs", "php-github-api", 1);
     }
 
     protected function getApiClass()


### PR DESCRIPTION
**I've made a couple of quick changes:**
- The deployments API has now been released so we don't need to send a special `Accept` header to use it anymore
- I felt that the `update` method was a bit misleading/unclear. Per [this page](https://developer.github.com/v3/repos/deployments/#update-a-deployment):

> Once a deployment is created, it cannot be updated. Information relating to the success or failure of a deployment is handled through Deployment Statuses.

As a result, I've renamed it to `updateStatus` to try and prevent confusion.
- I've added a few more doc blocks and links to GitHub's dev docs. Nothing too major.
- Added a new function for getting all of the deployment status updates for a given deployment.

**As for the tests**:
- In the spirit of the other tests, these work by mocking the API client and expecting certain functions to be called.
- I haven't added any functional tests since they appear to be disabled in the PHPUnit config file and I'm not familiar enough with the project to understand if these are required or not (they're not present for some other APIs).

**In terms of documentation:**
- I've added a markdown file for the API and linked it from the main list.

Thanks for your existing work on this, the existing code was nice to work with. Hopefully this can be pulled into knplabs/php-github-api soon.
